### PR TITLE
Fix for 'cljx once' is not a task. See 'lein help'.

### DIFF
--- a/src/leiningen/new/reagent/project.clj
+++ b/src/leiningen/new/reagent/project.clj
@@ -50,7 +50,7 @@
                    :env {:dev? true}
 
                    {{#cljx-hook?}}
-                   :prep-tasks ["cljx once"]
+                   :prep-tasks [["cljx" "once"]]
                    {{/cljx-hook?}}
                    {{#cljx-build?}}
                    :cljx {:builds [{:source-paths ["src/cljx"]


### PR DESCRIPTION
Create a new project using the `+cljx` argument and then run the server with `lein ring server`. It fails with the error:

```
 $ lein ring server
WARNING!!! version ranges found for:
[com.keminglabs/cljx "0.4.0"] -> [org.clojars.trptcolin/sjacket "0.1.0.6"] -> [org.clojure/clojure "[1.3.0,)"]
Consider using [com.keminglabs/cljx "0.4.0" :exclusions [org.clojure/clojure]].
[com.keminglabs/cljx "0.4.0"] -> [org.clojars.trptcolin/sjacket "0.1.0.6"] -> [net.cgrand/regex "1.1.0"] -[org.clojure/clojure "[1.2.0,)"]
Consider using [com.keminglabs/cljx "0.4.0" :exclusions [org.clojure/clojure]].
[com.keminglabs/cljx "0.4.0"] -> [org.clojars.trptcolin/sjacket "0.1.0.6"] -> [net.cgrand/parsley "0.9.1"] -> [org.clojure/clojure "[1.2.0,)"]
Consider using [com.keminglabs/cljx "0.4.0" :exclusions [org.clojure/clojure]].
[com.keminglabs/cljx "0.4.0"] -> [org.clojars.trptcolin/sjacket "0.1.0.6"] -> [net.cgrand/parsley "0.9.1"] -> [net.cgrand/regex "1.1.0"] -> [org.clojure/clojure "[1.2.0,)"]
Consider using [com.keminglabs/cljx "0.4.0" :exclusions [org.clojure/clojure]].

'cljx once' is not a task. See 'lein help'.
```

The attached patch fixes this.
