### PR TITLE
clean-up source map definition for dev mode

### DIFF
--- a/src/leiningen/new/reagent/project.clj
+++ b/src/leiningen/new/reagent/project.clj
@@ -61,7 +61,7 @@
                                     :rules :cljs}]}
                    {{/cljx-build?}}
                    :cljsbuild {:builds {:app {:source-paths ["env/dev/cljs"]
-                                              :compiler {:source-map "resources/public/js/out.js.map"}}}}}
+                                              :compiler {:source-map true}}}}}
 
              :uberjar {:hooks [{{cljx-uberjar-hook}}leiningen.cljsbuild minify-assets.plugin/hooks]
                        :env {:production true}


### PR DESCRIPTION
The source map filename does not seem to cause anything in dev mode as all the source maps are stored along the individual files and using their filename as a basis. Therefore it is better to just use `true` in project file than some name for a file that won't even get generated.
