### PR TITLE
add ring-handler to figwheel http server

### DIFF
--- a/src/leiningen/new/reagent/project.clj
+++ b/src/leiningen/new/reagent/project.clj
@@ -45,7 +45,8 @@
 
                    :figwheel {:http-server-root "public"
                               :server-port 3449
-                              :css-dirs ["resources/public/css"]}
+                              :css-dirs ["resources/public/css"]
+                              :ring-handler {{project-ns}}.handler/app}
 
                    :env {:dev? true}
 


### PR DESCRIPTION
This simplifies the development mode with figwheel. Now with `lein figwheel` there's no need to run `lein ring server` or `lein cljsbuild`.

To run the development server, run 

```
lein figwheel
```

Wait a bit, then browse to http://localhost:3449
