### PR TITLE
Update to accommodate clojurescript 0.0-2814, and corresponding changes in weasel

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reagent/lein-template "0.4.8"
+(defproject reagent/lein-template "0.4.9-SNAPSHOT"
   :description "A Leiningen template for a ClojureScript setup with Figwheel, Austin, and Reagent."
   :url "https://github.com/reagent-project/reagent-template"
   :license {:name "MIT License"

--- a/src/leiningen/new/reagent.clj
+++ b/src/leiningen/new/reagent.clj
@@ -31,8 +31,8 @@
 (def lib-or-app-dependencies
   "Dependencies for development or as part of an app."
   '[[org.clojure/clojurescript "0.0-2814" :scope "provided"]
-    [com.cemerick/piggieback "0.1.5"]
-    [weasel "0.5.0"]
+    [com.cemerick/piggieback "0.1.6-SNAPSHOT"]
+    [weasel "0.6.0-SNAPSHOT"]
     [ring "1.3.2"]
     [ring/ring-defaults "0.1.3"]
     [prone "0.8.0"]
@@ -40,7 +40,7 @@
     [selmer "0.8.0"]
     [environ "1.0.0"]
     [leiningen "2.5.1"]
-    [figwheel "0.1.6-SNAPSHOT"]])
+    [figwheel "0.2.3-SNAPSHOT"]])
 
 (def lib-or-app-plugins
   "Plugins for development or as part of an app."

--- a/src/leiningen/new/reagent/project.clj
+++ b/src/leiningen/new/reagent/project.clj
@@ -7,8 +7,8 @@
   :source-paths ["src/clj" "src/cljs"{{{cljx-source-paths}}}]
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.facebook/react "0.11.2"]
-                 [reagent "0.4.3"]
+                 [cljsjs/react "0.12.2-5"]
+                 [reagent "0.5.0-alpha3"]
                  [reagent-forms "0.4.3"]
                  [reagent-utils "0.1.2"]
                  [secretary "1.2.1"]{{{app-dependencies}}}]
@@ -33,7 +33,8 @@
   :cljsbuild {:builds {:app {:source-paths ["src/cljs"{{{cljx-cljsbuild-spath}}}]
                              :compiler {:output-to     "resources/public/js/app.js"
                                         :output-dir    "resources/public/js/out"
-                                        :externs       ["react/externs/react.js"]
+                                        ;;:externs       ["react/externs/react.js"]
+                                        :asset-path   "js/out"
                                         :optimizations :none
                                         :pretty-print  true}}}}
 
@@ -44,7 +45,7 @@
                                   [ring/ring-devel "1.3.2"]
                                   [pjstadig/humane-test-output "0.6.0"]{{{lib-dependencies}}}]
 
-                   :plugins [[lein-figwheel "0.2.0-SNAPSHOT"]{{{lib-plugins}}}{{{project-dev-plugins}}}]
+                   :plugins [[lein-figwheel "0.2.3-SNAPSHOT"]{{{lib-plugins}}}{{{project-dev-plugins}}}]
 
                    :injections [(require 'pjstadig.humane-test-output)
                                 (pjstadig.humane-test-output/activate!)]
@@ -68,7 +69,8 @@
                                     :rules :cljs}]}
                    {{/cljx-build?}}
                    :cljsbuild {:builds {:app {:source-paths ["env/dev/cljs"]
-                                              :compiler {:source-map true}}
+                                              :compiler {   :main "{{name}}.dev"
+                                                         :source-map true}}
                                         {{#test-hook?}}
                                         :test {:source-paths ["src/cljs" {{{cljx-cljsbuild-spath}}} "test/cljs"]
                                                :compiler {:output-to "target/test.js"
@@ -95,4 +97,6 @@
 
              :production {:ring {:open-browser? false
                                  :stacktraces?  false
-                                 :auto-reload?  false}}})
+                                 :auto-reload?  false}
+                          :cljsbuild {:builds {:app {:compiler {:main "{{name}}.prod"}}}}
+                          }})

--- a/src/leiningen/new/reagent/resources/templates/index.html
+++ b/src/leiningen/new/reagent/resources/templates/index.html
@@ -1,21 +1,10 @@
 <html>
   <head>
-    {% if dev %}
-      {% style "css/site.css" %}
-    {% else %}
-      {% style "css/site.min.css" %}
-    {% endif %}
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="css/site.css">
   </head>
   <body>
     <div id="app"></div>
-    {% if dev %}
-      <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.11.2/react.js"></script>
-      {% script "js/out/goog/base.js" %}
-      {% script "js/app.js" %}
-      <script type="text/javascript">goog.require("{{project-goog-module}}.dev");</script>
-    {% else %}
-      <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.11.2/react.min.js"></script>
-      {% script "js/app.js" %}
-    {% endif %}
+    <script src="js/app.js" type="text/javascript"></script>
   </body>
 </html>

--- a/src/leiningen/new/reagent/src/cljs/reagent/core.cljs
+++ b/src/leiningen/new/reagent/src/cljs/reagent/core.cljs
@@ -3,7 +3,8 @@
               [reagent.session :as session]
               [secretary.core :as secretary :include-macros true]
               [goog.events :as events]
-              [goog.history.EventType :as EventType])
+              [goog.history.EventType :as EventType]
+              [cljsjs.react :as react])
     (:import goog.History))
 
 ;; -------------------------


### PR DESCRIPTION
You might want to compare this to the changes you are planning to make.  There has been no comprehensive testing, but initial runs in a dev environment with figwheel have not completely collapsed.

Uses the new snapshot of weasel, the newish snapshot of piggieback, and the latest alpha of reagent.

Selmer templates have been stripped out of index.html.  I don't think they are required for dev and prod javascript, but I have also removed them for css.min.  If you decide to leave Selmer out, index.html could be moved up out of templates, I think.
