### PR TITLE
Update dev.clj to conform to new piggieback api (issue #50)

### DIFF
--- a/src/leiningen/new/reagent/env/dev/clj/reagent/dev.clj
+++ b/src/leiningen/new/reagent/env/dev/clj/reagent/dev.clj
@@ -4,7 +4,7 @@
             [leiningen.core.main :as lein]))
 
 (defn browser-repl []
-  (piggieback/cljs-repl :repl-env (weasel/repl-env :ip "127.0.0.1" :port 9001)))
+  (piggieback/cljs-repl (weasel/repl-env :ip "127.0.0.1" :port 9001)))
 
 (defn start-figwheel []
   (future


### PR DESCRIPTION
piggieback/cljs-repl now accepts a repl-env as the first argument instead of as a keyword argument.