### PR TITLE
Add figwheel_server.log to gitignore

### DIFF
--- a/src/leiningen/new/reagent/.gitignore
+++ b/src/leiningen/new/reagent/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 /resources/public/js
 /out
 /.repl
+figwheel_server.log


### PR DESCRIPTION
Pretty sure you don't want that in your Git repository.