### PR TITLE
There's no {{project-ns}}.dev

### DIFF
--- a/src/leiningen/new/reagent/env/dev/clj/reagent/repl.clj
+++ b/src/leiningen/new/reagent/env/dev/clj/reagent/repl.clj
@@ -1,6 +1,5 @@
 (ns {{name}}.repl
   (:use {{name}}.handler
-        {{project-ns}}.dev
         ring.server.standalone
         [ring.middleware file-info file]))
 


### PR DESCRIPTION
With the current setup there's errors when you run lein repl because it tries to load this file that doesn't exist.

The clojurescript file only exists in the cljs flavour, not clj.