### PR TITLE
Bump version of clojurescript.test 0.3.2 -> 0.3.3

### DIFF
--- a/src/leiningen/new/reagent.clj
+++ b/src/leiningen/new/reagent.clj
@@ -34,7 +34,7 @@
 (defn test? [opts]
   (some #{"+test"} opts))
 
-(def test-plugin "com.cemerick/clojurescript.test \"0.3.2\"")
+(def test-plugin "com.cemerick/clojurescript.test \"0.3.3\"")
 
 (def test-source-paths "\"src/cljs\" \"test/cljs\"")
 


### PR DESCRIPTION
Version 0.3.3 allows running tests with PhantomJS that access
localStorage