### PR TITLE
Include refactor-nrepl with the +cider flag

### DIFF
--- a/src/leiningen/new/reagent/project.clj
+++ b/src/leiningen/new/reagent/project.clj
@@ -64,8 +64,8 @@
                    :plugins [[lein-figwheel "0.4.1"]
                              {{#cider-hook?}}
                              [cider/cider-nrepl "0.10.0-SNAPSHOT"]
-                             {{/cider-hook?}}
                              [refactor-nrepl "2.0.0-SNAPSHOT"]
+                             {{/cider-hook?}}
                              [lein-cljsbuild "1.1.0"]{{{project-dev-plugins}}}]
 
                    :injections [(require 'pjstadig.humane-test-output)
@@ -77,8 +77,8 @@
                               :nrepl-middleware ["cemerick.piggieback/wrap-cljs-repl"
                                                  {{#cider-hook?}}
                                                  "cider.nrepl/cider-middleware"
-                                                 {{/cider-hook?}}
                                                  "refactor-nrepl.middleware/wrap-refactor"
+                                                 {{/cider-hook?}}
                                                  ]
                               :css-dirs ["resources/public/css"]
                               :ring-handler {{project-ns}}.handler/app}


### PR DESCRIPTION
Based on history, it looks like the refactor-nrepl plugin should be included only with the +cider flag.

The plugin was originally added as part of ["add +cider flag"](https://github.com/reagent-project/reagent-template/commit/57bb972ff97bc63a19768c7d30605d2d11c4502d), but the template conditionals weren't formatted correctly, fixed in ["fixed typo"](https://github.com/reagent-project/reagent-template/commit/c26dcbd7f0f64270077b82ade84820b9b7d6b459).
