### PR TITLE
fix outdated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,7 @@ and stopped by running:
 ### Building for release
 
 ```
-lein cljsbuild clean
-lein uberjar
+lein do clean, uberjar
 ```
 
 ### Deploying to Heroku


### PR DESCRIPTION
`lein-cljsbuild` doesn't have `clean` subtask now, we just need to configure `:clean-targets` properly and use `lein clean`