### PR TITLE
nearly isomorphic routing with accountant library

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The template packages everything you need to create a production ready ClojureSc
 * [reagent-forms](https://github.com/reagent-project/reagent-forms) - data binding library for Reagent
 * [reagent-utils](https://github.com/reagent-project/reagent-utils) - utilities such as session and cookie management
 * [Secretary](https://github.com/gf3/secretary) - client-side routing
+* [Accountant](https://github.com/venantius/accountant) - additional setup facilities for client-side routing in SPA way
 * [Hiccup](https://github.com/weavejester/hiccup) - server-side HTML templating
 * [Compojure](https://github.com/weavejester/compojure) - a popular routing library
 * [Ring](https://github.com/ring-clojure/ring) - Clojure HTTP interface

--- a/src/leiningen/new/reagent/project.clj
+++ b/src/leiningen/new/reagent/project.clj
@@ -17,6 +17,7 @@
                  [environ "1.0.1"]
                  [org.clojure/clojurescript "1.7.145" :scope "provided"]
                  [secretary "1.2.3"]
+                 [venantius/accountant "0.1.4"]
                  {{#devcards-hook?}} [devcards "0.2.0-8"] {{/devcards-hook?}}
                  {{{app-dependencies}}}]
 

--- a/src/leiningen/new/reagent/src/clj/reagent/handler.clj
+++ b/src/leiningen/new/reagent/src/clj/reagent/handler.clj
@@ -15,7 +15,7 @@
        [:b "lein figwheel"]
        " in order to start the compiler"]])
 
-(def home-page
+(def loading-page
   (html
    [:html
     [:head
@@ -38,7 +38,8 @@
      (include-js "js/app_devcards.js")]])){{/devcards-hook?}}
 
 (defroutes routes
-  (GET "/" [] home-page)
+  (GET "/" [] loading-page)
+  (GET "/about" [] loading-page)
   {{#devcards-hook?}}(GET "/cards" [] cards-page){{/devcards-hook?}}
   (resources "/")
   (not-found "Not Found"))

--- a/src/leiningen/new/reagent/src/cljs/reagent/core.cljs
+++ b/src/leiningen/new/reagent/src/cljs/reagent/core.cljs
@@ -2,27 +2,24 @@
     (:require [reagent.core :as reagent :refer [atom]]
               [reagent.session :as session]
               [secretary.core :as secretary :include-macros true]
-              [goog.events :as events]
-              [goog.history.EventType :as EventType])
-    (:import goog.History))
+              [accountant.core :as accountant]))
 
 ;; -------------------------
 ;; Views
 
 (defn home-page []
   [:div [:h2 "Welcome to {{name}}"]
-   [:div [:a {:href "#/about"} "go to about page"]]])
+   [:div [:a {:href "/about"} "go to about page"]]])
 
 (defn about-page []
   [:div [:h2 "About {{name}}"]
-   [:div [:a {:href "#/"} "go to the home page"]]])
+   [:div [:a {:href "/"} "go to the home page"]]])
 
 (defn current-page []
   [:div [(session/get :current-page)]])
 
 ;; -------------------------
 ;; Routes
-(secretary/set-config! :prefix "#")
 
 (secretary/defroute "/" []
   (session/put! :current-page #'home-page))
@@ -31,21 +28,12 @@
   (session/put! :current-page #'about-page))
 
 ;; -------------------------
-;; History
-;; must be called after routes have been defined
-(defn hook-browser-navigation! []
-  (doto (History.)
-    (events/listen
-     EventType/NAVIGATE
-     (fn [event]
-       (secretary/dispatch! (.-token event))))
-    (.setEnabled true)))
-
-;; -------------------------
 ;; Initialize app
+
 (defn mount-root []
   (reagent/render [current-page] (.getElementById js/document "app")))
 
 (defn init! []
-  (hook-browser-navigation!)
+  (accountant/configure-navigation!)
+  (accountant/dispatch-current!)
   (mount-root))


### PR DESCRIPTION
This idiomatic change suggest to use [accountant](https://github.com/venantius/accountant) library for client-side rounting configuration.
The main idea is to use non-fragment hrefs and handle clicks via dom events.
If browser is capable enough and routes for href path is present, page will not cause reloading.

You may see an example at http://isomorph.clj.rocks . No matter, which browser you use - firefox, chrome or links. It will be routed correctly.

Changes summary:
- add server-side routes
- all href pointing to some-side client route will not cause page reload
- goog browser history api setup via accountant
- direct links to pages dispatched by client-side routes