### PR TITLE
remove nonexists macro

### DIFF
--- a/src/leiningen/new/reagent/test/cljs/reagent/core_test.cljs
+++ b/src/leiningen/new/reagent/test/cljs/reagent/core_test.cljs
@@ -1,5 +1,5 @@
 (ns {{project-ns}}.core-test
-  (:require [cljs.test :refer-macros [is are deftest testing use-fixtures done]]
+  (:require [cljs.test :refer-macros [is are deftest testing use-fixtures]]
             [reagent.core :as reagent :refer [atom]]
             [{{project-ns}}.core :as rc]))
 


### PR DESCRIPTION
cause we use `cljs.test` here so should remove the nonexists macro `done` to prevent error like, the `done` macro is part of the deprecate project [clojurescript.test](https://github.com/cemerick/clojurescript.test)

```
Caused by: clojure.lang.ExceptionInfo: Referred macro cljs.test/done does not exist {:tag :cljs/analysis-error}
```