### PR TITLE
Use Hiccup's `html5' instead of `html'

### DIFF
--- a/src/leiningen/new/reagent/src/clj/reagent/handler.clj
+++ b/src/leiningen/new/reagent/src/clj/reagent/handler.clj
@@ -1,8 +1,7 @@
 (ns {{project-ns}}.handler
   (:require [compojure.core :refer [GET defroutes]]
             [compojure.route :refer [not-found resources]]
-            [hiccup.core :refer [html]]
-            [hiccup.page :refer [include-js include-css]]
+            [hiccup.page :refer [include-js include-css html5]]
             [{{name}}.middleware :refer [wrap-middleware]]
             [environ.core :refer [env]]))
 
@@ -14,26 +13,24 @@
        " in order to start the compiler"]])
 
 (def loading-page
-  (html
-   [:html
-    [:head
+  (html5
+   [:head
      [:meta {:charset "utf-8"}]
      [:meta {:name "viewport"
              :content "width=device-width, initial-scale=1"}]
      (include-css (if (env :dev) "css/site.css" "css/site.min.css"))]
     [:body
      mount-target
-     (include-js "js/app.js")]]))
+     (include-js "js/app.js")]))
 {{#devcards-hook?}}
 
 (def cards-page
-  (html
-   [:html
-    [:head
+  (html5
+   [:head
      [:meta {:charset "utf-8"}]]
     [:body
      mount-target
-     (include-js "js/app_devcards.js")]])){{/devcards-hook?}}
+     (include-js "js/app_devcards.js")])){{/devcards-hook?}}
 
 (defroutes routes
   (GET "/" [] loading-page)


### PR DESCRIPTION
`[:html]` is already implied in `html5`, so it can be removed.

`html5` also includes stuff like `<!DOCTYPE html>`, which are necessary to correctly render some Bootstrap stuff (and other css frameworks I would assume.)