### PR TITLE
avoiding conflits between devcards css and reagent site.css

### DIFF
--- a/resources/leiningen/new/reagent/resources/public/css/site.css
+++ b/resources/leiningen/new/reagent/resources/public/css/site.css
@@ -1,4 +1,4 @@
-body {
+.body-container {
   font-family: 'Helvetica Neue', Verdana, Helvetica, Arial, sans-serif;
   max-width: 600px;
   margin: 0 auto;

--- a/resources/leiningen/new/reagent/src/clj/reagent/handler.clj
+++ b/resources/leiningen/new/reagent/src/clj/reagent/handler.clj
@@ -22,7 +22,7 @@
 (def loading-page
   (html5
     (head)
-    [:body
+    [:body {:class "body-container"}
      mount-target
      (include-js "/js/app.js")]))
 {{#devcards-hook?}}


### PR DESCRIPTION
The devcards CSS and the ``site.css`` site conflits for styling body element. I don't know if this minor fix is fine for the project, but works for me. So...