### PR TITLE
Bump devcards, fixes #120

### DIFF
--- a/resources/leiningen/new/reagent/project.clj
+++ b/resources/leiningen/new/reagent/project.clj
@@ -131,7 +131,7 @@
                    :dependencies [[ring/ring-mock "0.3.0"]
                                   [ring/ring-devel "1.5.0"]
                                   [prone "1.1.1"]
-                                  [lein-figwheel "0.5.4-SNAPSHOT"
+                                  [lein-figwheel "0.5.4"
                                    :exclusions [org.clojure/core.memoize
                                                 ring/ring-core
                                                 org.clojure/clojure
@@ -150,14 +150,14 @@
                                   [speclj "3.3.1"]
                                   {{/spec-hook?}}
                                   {{#devcards-hook?}}
-                                  [devcards "0.2.0-8"
+                                  [devcards "0.2.1-7"
                                    :exclusions [org.clojure/tools.reader]]
                                   {{/devcards-hook?}}
                                   [pjstadig/humane-test-output "0.8.0"]
                                   {{dev-dependencies}}]
 
                    :source-paths ["env/dev/clj"]
-                   :plugins [[lein-figwheel "0.5.4-SNAPSHOT"
+                   :plugins [[lein-figwheel "0.5.4"
                               :exclusions [org.clojure/core.memoize
                                            ring/ring-core
                                            org.clojure/clojure


### PR DESCRIPTION
Outdated `devcards`' `React` dependency was conflicting with `figwheel` and `reagent`.