### PR TITLE
Support for Figwheel and Piggieback from REPL

### DIFF
--- a/resources/leiningen/new/reagent/env/dev/clj/reagent/repl.clj
+++ b/resources/leiningen/new/reagent/env/dev/clj/reagent/repl.clj
@@ -1,5 +1,6 @@
 (ns {{name}}.repl
   (:use {{name}}.handler
+        figwheel-sidecar.repl-api
         ring.server.standalone
         [ring.middleware file-info file]))
 

--- a/resources/leiningen/new/reagent/project.clj
+++ b/resources/leiningen/new/reagent/project.clj
@@ -99,7 +99,7 @@
    {{/spec-hook?}}
    }
 
-  {{#spec-hook?}}
+{{#spec-hook?}}
    :doo {:build "test"}
    {{/spec-hook?}}
 
@@ -126,7 +126,8 @@
          :dst "resources/public/css"}
   {{/sass-hook?}}
 
-  :profiles {:dev {:repl-options {:init-ns {{project-ns}}.repl}
+  :profiles {:dev {:repl-options {:init-ns {{project-ns}}.repl
+                                  :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
 
                    :dependencies [[ring/ring-mock "0.3.0"]
                                   [ring/ring-devel "1.5.0"]


### PR DESCRIPTION
Enable start-figwheel! and cljs-repl from the repl namespace.
