### PR TITLE
Sass enhancements

### DIFF
--- a/resources/leiningen/new/reagent/gitignore
+++ b/resources/leiningen/new/reagent/gitignore
@@ -9,7 +9,9 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 /resources/public/js
+/resources/public/css
 /out
 /.repl
 *.log
 /.env
+/.sass-cache

--- a/resources/leiningen/new/reagent/src/sass/site.scss
+++ b/resources/leiningen/new/reagent/src/sass/site.scss
@@ -1,0 +1,44 @@
+// Uncomment to import other sass or scss files
+// @import 'index';
+// @import 'profile';
+
+// You can use any sass features, like variables, for instance:
+$font-stack: 'Helvetica Neue', Verdana, Helvetica, Arial, sans-serif;
+$base-font-size: 1.125em;
+
+.body-container {
+  font-family: $font-stack;
+  max-width: 600px;
+  margin: 0 auto;
+  padding-top: 72px;
+  -webkit-font-smoothing: antialiased;
+  font-size: $base-font-size;
+  color: #333;
+  line-height: 1.5em;
+}
+
+h1, h2, h3 {
+  color: #000;
+}
+
+h1 {
+  font-size: $base-font-size + 1.375;
+}
+
+h2 {
+  font-size: $base-font-size + 0.875;
+}
+
+h3 {
+  font-size: $base-font-size + 0.125;
+}
+
+a {
+  text-decoration: none;
+  color: #09f;
+
+ // nesting is also supported
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/src/leiningen/new/reagent.clj
+++ b/src/leiningen/new/reagent.clj
@@ -112,6 +112,7 @@
                args)
         args (if (sass? opts)
                (conj args
+                     ["src/sass/site.scss" (render "src/sass/site.scss" data)]
                      ["src/sass/index.sass" (render "src/sass/index.sass" data)]
                      ["src/sass/profile.scss" (render "src/sass/profile.scss" data)])
                args)


### PR DESCRIPTION
- Adding a site.scss to illustrate the use of sass, and to be able to have live reloading of sass right from the start after running "lein sass watch" when a new project is created with the "+sass" option.
- Adding additional ignore entries to the `.gitignore` file, to ignore the output of the CSS resources and also to ignore the folder that is generated when building sass stylesheets that is used as a local cache.