### PR TITLE
Fix foreman start

### DIFF
--- a/resources/leiningen/new/reagent/src/clj/reagent/server.clj
+++ b/resources/leiningen/new/reagent/src/clj/reagent/server.clj
@@ -1,9 +1,9 @@
 (ns {{project-ns}}.server
-  (:require [{{project-ns}}.handler :refer [app]]
-            [config.core :refer [env]]
-            [ring.adapter.jetty :refer [run-jetty]])
-  (:gen-class))
+    (:require [{{project-ns}}.handler :refer [app]]
+              [config.core :refer [env]]
+              [ring.adapter.jetty :refer [run-jetty]])
+    (:gen-class))
 
- (defn -main [& args]
-   (let [port (Integer/parseInt (or (env :port) "3000"))]
-     (run-jetty app {:port port :join? false})))
+(defn -main [& args]
+  (let [port (or (env :port) 3000)]
+    (run-jetty app {:port port :join? false})))


### PR DESCRIPTION
Without this change, running `forman start` or `forman start -p 1234` gives rise to
`java.lang.ClassCastException: java.lang.Long cannot be cast to
java.lang.String` since `(env :port)` is a Long.