### PR TITLE
Add dependencies for cemerick.piggieback

### DIFF
--- a/resources/leiningen/new/reagent/project.clj
+++ b/resources/leiningen/new/reagent/project.clj
@@ -134,7 +134,8 @@
   :profiles {:dev {:repl-options {:init-ns {{project-ns}}.repl
                                   :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
 
-                   :dependencies [[binaryage/devtools "0.9.10"]
+                   :dependencies [[com.cemerick/piggieback "0.2.0"]
+                                  [binaryage/devtools "0.9.10"]
                                   [ring/ring-mock "0.3.2"]
                                   [ring/ring-devel "1.6.3"]
                                   [prone "1.5.2"]


### PR DESCRIPTION
[VSCode Clojure plugin](https://marketplace.visualstudio.com/items?itemName=avli.clojure) can't starts in projects build-on reagent-template:

```bash
Error loading cemerick.piggieback: Could not locate cemerick/piggieback__init.class or cemerick/piggieback.clj on classpath.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by dynapath.defaults$eval31204$fn__31205 to method java.net.URLClassLoader.addURL(java.net.URL)
WARNING: Please consider reporting this to the maintainers of dynapath.defaults$eval31204$fn__31205
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Exception in thread "main" java.lang.RuntimeException: Unable to resolve var: cemerick.piggieback/wrap-cljs-repl in this context, compiling:(/private/var/folders/bz/pl5bckcx78l953vct2p4pn21gytcnd/T/form-init11562013848030067845.clj:1:8890)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7010)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$InvokeExpr.parse(Compiler.java:3881)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7005)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$InvokeExpr.parse(Compiler.java:3881)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7005)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.access$300(Compiler.java:38)
	at clojure.lang.Compiler$LetExpr$Parser.parse(Compiler.java:6368)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7003)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:6100)
	at clojure.lang.Compiler$FnMethod.parse(Compiler.java:5460)
	at clojure.lang.Compiler$FnExpr.parse(Compiler.java:4022)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7001)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.eval(Compiler.java:7059)
	at clojure.lang.Compiler.eval(Compiler.java:7052)
	at clojure.lang.Compiler.load(Compiler.java:7514)
	at clojure.lang.Compiler.loadFile(Compiler.java:7452)
	at clojure.main$load_script.invokeStatic(main.clj:278)
	at clojure.main$init_opt.invokeStatic(main.clj:280)
	at clojure.main$init_opt.invoke(main.clj:280)
	at clojure.main$initialize.invokeStatic(main.clj:311)
	at clojure.main$null_opt.invokeStatic(main.clj:345)
	at clojure.main$null_opt.invoke(main.clj:342)
	at clojure.main$main.invokeStatic(main.clj:424)
	at clojure.main$main.doInvoke(main.clj:387)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:702)
	at clojure.main.main(main.java:37)
Caused by: java.lang.RuntimeException: Unable to resolve var: cemerick.piggieback/wrap-cljs-repl in this context
	at clojure.lang.Util.runtimeException(Util.java:221)
	at clojure.lang.Compiler$TheVarExpr$Parser.parse(Compiler.java:720)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7003)
	... 34 more
Subprocess failed
nREPL exited with code 1
```

**java 10.0.2**
**lein 2.8.1**

Workarounds are [to change cemerick -> cider](https://github.com/bhauman/lein-figwheel/issues/689). But I decided just add needed dependencies. Also [similar issue was existed](https://github.com/reagent-project/reagent-template/issues/54).