### PR TITLE
Add Clerk as an opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ The template packages everything you need to create a production ready ClojureSc
 * [reagent-forms](https://github.com/reagent-project/reagent-forms) - data binding library for Reagent
 * [reagent-utils](https://github.com/reagent-project/reagent-utils) - utilities such as session and cookie management
 * [Reitit](https://metosin.github.io/reitit/) - Routing, server and client side
-* [Accountant](https://github.com/venantius/accountant) - additional setup facilities for client-side routing in SPA way
+* [Accountant](https://github.com/venantius/accountant) - HTML5 history management, enabling href navigation in SPAs
+* [Clerk](https://github.com/PEZ/clerk) - In page navigation for SPAs. Scroll restoration, anchor targeting, and such.
 * [Hiccup](https://github.com/weavejester/hiccup) - server-side HTML templating
 * [Ring](https://github.com/ring-clojure/ring) - Clojure HTTP interface
 * [Prone](https://github.com/magnars/prone) - better exception reporting middleware for Ring
@@ -183,6 +184,7 @@ The template supports the following options:
 * `+sass` - use [sass](https://github.com/Deraen/sass4clj) for compiling Sass/Scss CSS files
 * `+devcards` - add [Devcards](https://github.com/bhauman/devcards) support
 * `+cider` - add [CIDER](https://github.com/clojure-emacs/cider) support
+* `-clerk` - do not add [Clerk](https://github.com/PEZ/clerk) support
 
 ## Contributing & Customizing
 

--- a/resources/leiningen/new/reagent/project.clj
+++ b/resources/leiningen/new/reagent/project.clj
@@ -15,6 +15,9 @@
                  [org.clojure/clojurescript "1.10.339"
                   :scope "provided"]
                  [metosin/reitit "0.2.4"]
+                 {{#clerk-hook?}}
+                 [pez/clerk "1.0.0"]
+                 {{/clerk-hook?}}
                  [venantius/accountant "0.2.4"
                   :exclusions [org.clojure/tools.reader]]]
 

--- a/src/leiningen/new/reagent.clj
+++ b/src/leiningen/new/reagent.clj
@@ -16,7 +16,7 @@
 (defn indent [n list]
   (wrap-indent identity n list))
 
-(def valid-opts ["+test" "+spec" "+less" "+sass" "+devcards" "+cider" "+reitit"])
+(def valid-opts ["+test" "+spec" "+less" "+sass" "+devcards" "+cider" "-clerk"])
 
 (defn less? [opts]
   (some #{"+less"} opts))
@@ -35,6 +35,9 @@
 
 (defn cider? [opts]
   (some #{"+cider"} opts))
+
+(defn clerk? [opts]
+  (not (some #{"-clerk"} opts)))
 
 (defn validate-opts [opts]
   (let [invalid-opts (remove (set valid-opts) opts)]
@@ -56,31 +59,28 @@
    :project-goog-module (sanitize (sanitize-ns name))
    :project-ns (sanitize-ns name)
    :sanitized (name-to-path name)
-
+  
    :jvm-opts-hook? (fn [block] (if (jvm>8?) (str block "") ""))
-     ;; test
+  
    :test-hook? (fn [block] (if (test? opts) (str block "") ""))
-
-     ;; spec
+  
    :spec-hook? (fn [block] (if (spec? opts) (str block "") ""))
-
+  
    :test-or-spec-hook?
    (fn [block] (if (or (test? opts) (spec? opts)) (str block "") ""))
-
-     ;; less
+  
    :less-hook? (fn [block] (if (less? opts) (str block "") ""))
-
-     ;; sass
+  
    :sass-hook? (fn [block] (if (sass? opts) (str block "") ""))
-
+  
    :less-or-sass-hook?
    (fn [block] (if (or (less? opts) (sass? opts)) (str block "") ""))
-
-     ;; devcards
+  
    :devcards-hook? (fn [block] (if (devcards? opts) (str block "") ""))
-
-     ;; cider
-   :cider-hook? (fn [block] (if (cider? opts) (str block "") ""))})
+  
+   :cider-hook? (fn [block] (if (cider? opts) (str block "") ""))
+  
+   :clerk-hook? (fn [block] (if (clerk? opts) (str block "") ""))})
 
 (defn format-files-args [name opts]
   (let [data (template-data name opts)


### PR DESCRIPTION
Clerks's scroll position management makes sense in many projects where the SPA should mimic a regular multipage site. But there are also cases where it might not be helpful. So that's why I am adding Clerk as an opt-out here.

Let me know if that does not make sense to you. 😄 
