### PR TITLE
Devcards template part don't work at the moment.

### DIFF
--- a/resources/leiningen/new/reagent/project.clj
+++ b/resources/leiningen/new/reagent/project.clj
@@ -141,7 +141,7 @@
                                   [speclj "3.3.2"]
                                   {{/spec-hook?}}
                                   {{#devcards-hook?}}
-                                  [devcards "0.2.3" :exclusions [cljsjs/react]]
+                                  [devcards "0.2.6" :exclusions [cljsjs/react]]
                                   {{/devcards-hook?}}
                                   [pjstadig/humane-test-output "0.9.0"]
                                   {{dev-dependencies}}

--- a/resources/leiningen/new/reagent/src/clj/reagent/handler.clj
+++ b/resources/leiningen/new/reagent/src/clj/reagent/handler.clj
@@ -42,7 +42,9 @@
 
 (defn cards-handler
   [_]
-  {:status 200 :body (cards-page)})
+  {:status 200
+   :headers {"Content-Type" "text/html"}
+   :body (cards-page)})
 {{/devcards-hook?}}
 
 (def app
@@ -54,7 +56,7 @@
       ["/:item-id" {:get {:handler index-handler
                           :parameters {:path {:item-id int?}}}}]]
       {{#devcards-hook?}}
-      ["cards" {:get {:handler cards-handler}}]
+      ["/cards" {:get {:handler cards-handler}}]
       {{/devcards-hook?}}
      ["/about" {:get {:handler index-handler}}]]
     {:data {:middleware middleware}})


### PR DESCRIPTION
This pr fix template devcards specific defaults when +devcards flag is used..

List of fixes :
* fix server side route for devcards
  Currently localhost:3449/cards have no active mapping due to typo in routes definition, so devcards don't displayed at all. 
* add headers for devcards page
  Without headers page don't interpreted as html and not displayed properly. For example in firefox it is just downloaded as text file
* bump devcards version to 0.2.6
  When devcards are displayed they fail with React.createClass errors. Looks like this is some deprecation in React itself. Bumping devcards to the recent release fixes this. 
