### PR TITLE
add default devcards route

### DIFF
--- a/resources/leiningen/new/reagent/src/clj/reagent/handler.clj
+++ b/resources/leiningen/new/reagent/src/clj/reagent/handler.clj
@@ -56,7 +56,8 @@
       ["" {:get {:handler index-handler}}]
       ["/:item-id" {:get {:handler index-handler
                           :parameters {:path {:item-id int?}}}}]]
-     ["/about" {:get {:handler index-handler}}]])
+     ["/about" {:get {:handler index-handler}}]{{#devcards-hook?}}
+     ["/cards" {:get {:handler cards-handler}}]{{/devcards-hook?}}])
    (reitit-ring/routes
     (reitit-ring/create-resource-handler {:path "/" :root "/public"})
     (reitit-ring/create-default-handler))


### PR DESCRIPTION
Looks like default devcards route was removed in 4c31914c92803e2d1c42ce401abacc87d63a8c55 . This change is adding it back. 