### PR TITLE
link typo fix: /borken/link -> /broken/link; site.css max-width changes to 640px

### DIFF
--- a/resources/leiningen/new/reagent/resources/public/css/site.css
+++ b/resources/leiningen/new/reagent/resources/public/css/site.css
@@ -1,6 +1,6 @@
 .body-container {
   font-family: 'Helvetica Neue', Verdana, Helvetica, Arial, sans-serif;
-  max-width: 600px;
+  max-width: 640px;
   margin: 0 auto;
   padding-top: 72px;
   -webkit-font-smoothing: antialiased;

--- a/resources/leiningen/new/reagent/src/cljs/reagent/core.cljs
+++ b/resources/leiningen/new/reagent/src/cljs/reagent/core.cljs
@@ -32,7 +32,7 @@
      [:h1 "Welcome to {{name}}"]
      [:ul
       [:li [:a {:href (path-for :items)} "Items of {{name}}"]]
-      [:li [:a {:href "/borken/link"} "Broken link"]]]]))
+      [:li [:a {:href "/broken/link"} "Broken link"]]]]))
 
 
 


### PR DESCRIPTION
There are 2 changes in this PR:
- link typo fix: /borken/link -> /**broken**/link

- site.css max-width changes to 640px. Original max-width is 600px, which breaks `reagent-tutorial` into 2 lines. Changing it to 640px makes it more user friendly.