### PR TITLE
Use `project-goog-module` inside script tag

### DIFF
--- a/resources/leiningen/new/reagent/src/clj/reagent/handler.clj
+++ b/resources/leiningen/new/reagent/src/clj/reagent/handler.clj
@@ -24,7 +24,7 @@
    [:body {:class "body-container"}
     mount-target
     (include-js "/js/app.js"){{#shadow-cljs-hook?}}
-    [:script "{{project-ns}}.core.init_BANG_()"]{{/shadow-cljs-hook?}}]))
+    [:script "{{project-goog-module}}.core.init_BANG_()"]{{/shadow-cljs-hook?}}]))
 
 {{#devcards-hook?}}
 


### PR DESCRIPTION
In JavaScript, `my-app` is not a valid variable name. It should be `my_app` under `window` object.