### PR TITLE
Fix reagent.core/render deprecated warning

### DIFF
--- a/resources/leiningen/new/reagent/src/cljs/reagent/core.cljs
+++ b/resources/leiningen/new/reagent/src/cljs/reagent/core.cljs
@@ -1,6 +1,7 @@
 (ns {{project-ns}}.core
   (:require
    [reagent.core :as reagent :refer [atom]]
+   [reagent.dom :as rdom]
    [reagent.session :as session]
    [reitit.frontend :as reitit]
    {{#clerk-hook?}}[clerk.core :as clerk]{{/clerk-hook?}}
@@ -89,7 +90,7 @@
 ;; Initialize app
 
 (defn mount-root []
-  (reagent/render [current-page] (.getElementById js/document "app")))
+  (rdom/render [current-page] (.getElementById js/document "app")))
 
 (defn init! []
   {{#clerk-hook?}}


### PR DESCRIPTION
reagent.core/render was [deprecated](https://reagent-project.github.io/docs/master/reagent.core.html#var-render) in 0.10.0 in favor of reagent.dom/render.