### PR TITLE
Fix Reagent deprecation warnings on tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To enable [cljs.test](https://github.com/clojure/clojurescript/blob/master/src/m
 ```
 lein new reagent <name> +test
 ```
-To run the tests, please use `lein doo phantom test once`. For installation instructions of PhantomJS, please see [this](http://phantomjs.org/download.html).
+To run the tests using headless chrome first install karma and its plugins `npm install -g karma-cli && npm install karma karma-cljs-test karma-chrome-launcher --save-dev`, then use `lein doo chrome-headless test once`. For other environments please check [doo's documentation](https://github.com/bensu/doo#setting-up-environments).
 
 To enable [speclj](https://github.com/slagyr/speclj) with [PhantomJS](http://phantomjs.org/), use `+spec` flag:
 

--- a/resources/leiningen/new/reagent/README.md
+++ b/resources/leiningen/new/reagent/README.md
@@ -69,11 +69,16 @@ and stopped by running:
 ## Running the tests
 {{/test-or-spec-hook?}}
 {{#test-hook?}}
-To run [cljs.test](https://github.com/clojure/clojurescript/blob/master/src/main/cljs/cljs/test.cljs) tests, please use
+To run [cljs.test](https://github.com/clojure/clojurescript/blob/master/src/main/cljs/cljs/test.cljs) tests using headless chrome install karma and its plugins:
 
 ```
-lein doo
+npm install -g karma-cli
+npm install karma karma-cljs-test karma-chrome-launcher --save-dev
+lein doo chrome-headless test once
 ```
+
+For other environments please check [doo's documentation](https://github.com/bensu/doo#setting-up-environments).
+
 {{/test-hook?}}
 {{#spec-hook?}}
 

--- a/resources/leiningen/new/reagent/gitignore
+++ b/resources/leiningen/new/reagent/gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 *.log
 /.env
 /.sass-cache
+/node_modules

--- a/resources/leiningen/new/reagent/spec/cljs/reagent/core_spec.cljs
+++ b/resources/leiningen/new/reagent/spec/cljs/reagent/core_spec.cljs
@@ -2,6 +2,7 @@
   (:require-macros [speclj.core :refer [describe it should= should should-not]])
   (:require [speclj.core]
             [reagent.core :as reagent :refer [atom]]
+            [reagent.dom :as rdom]
             [{{project-ns}}.core :as rc]))
 
 
@@ -20,9 +21,9 @@
 (defn with-mounted-component [comp f]
   (when isClient
     (let [div (add-test-div "_testreagent")]
-      (let [comp (reagent/render-component comp div #(f comp div))]
-        (reagent/unmount-component-at-node div)
-        (reagent/flush)
+      (let [comp (rdom/render comp div #(f comp div))]
+        (rdom/unmount-component-at-node div)
+        (rflush)
         (.removeChild (.-body js/document) div)))))
 
 

--- a/resources/leiningen/new/reagent/test/cljs/reagent/core_test.cljs
+++ b/resources/leiningen/new/reagent/test/cljs/reagent/core_test.cljs
@@ -2,6 +2,7 @@
   (:require
    [cljs.test :refer-macros [is are deftest testing use-fixtures]]
    [reagent.core :as reagent :refer [atom]]
+   [reagent.dom :as rdom]
    [{{project-ns}}.core :as rc]))
 
 
@@ -20,9 +21,9 @@
 (defn with-mounted-component [comp f]
   (when isClient
     (let [div (add-test-div "_testreagent")]
-      (let [comp (reagent/render-component comp div #(f comp div))]
-        (reagent/unmount-component-at-node div)
-        (reagent/flush)
+      (let [comp (rdom/render comp div #(f comp div))]
+        (rdom/unmount-component-at-node div)
+        (rflush)
         (.removeChild (.-body js/document) div)))))
 
 


### PR DESCRIPTION
Fixes Reagent warnings in tests generated by flags +test or +spec.

Also modified README suggesting chrome-headless instead of PhantomJS as a JS env to run doo.

Oh! Forgot to mention, the +spec tests are still broken.