### PR TITLE
Remove use of deprecated reagent.core/render

### DIFF
--- a/resources/leiningen/new/reagent/env/dev/cljs/reagent/cards.cljs
+++ b/resources/leiningen/new/reagent/env/dev/cljs/reagent/cards.cljs
@@ -1,5 +1,6 @@
 (ns {{project-ns}}.cards
   (:require [reagent.core :as reagent :refer [atom]]
+            [reagent.dom :as rdom]
             [{{project-ns}}.core :as core]
             [devcards.core :as dc])
   (:require-macros
@@ -13,7 +14,7 @@
 (defcard-rg home-page-card
   [core/home-page])
 
-(reagent/render [:div] (.getElementById js/document "app"))
+(rdom/render [:div] (.getElementById js/document "app"))
 
 ;; remember to run 'lein figwheel devcards' and then browse to
 ;; http://localhost:3449/cards


### PR DESCRIPTION
Currently a fresh project with DevCards will throw a warning due to this deprecated function.