### PR TITLE
Use heroku local instead of foreman

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,11 @@ shadow-cljs release app
 
 The project generates a `system.properties` used for Heroku deployments. Make sure you have [Git](http://git-scm.com/downloads) and [Heroku toolbelt](https://toolbelt.heroku.com/) installed, then simply follow the steps below.
 
-Optionally, test that your application runs locally with foreman by running.
+Optionally, test that your application runs locally by running.
 
 ```
-foreman start
+lein do clean, uberjar
+heroku local
 ```
 
 Now, you can initialize your git repo and commit your application.


### PR DESCRIPTION
Heroku local has replaced foreman:

https://devcenter.heroku.com/changelog-items/692

(it is still possible to use foreman https://devcenter.heroku.com/articles/heroku-local#run-your-app-locally-using-foreman but not officially supported, so the documentation should probably suggest the supported approach?).