### PR TITLE
Use recommend shadow-cljs setup for init/reload

### DIFF
--- a/resources/leiningen/new/reagent/shadow-cljs.edn
+++ b/resources/leiningen/new/reagent/shadow-cljs.edn
@@ -2,7 +2,6 @@
  :builds       {:app {:target     :browser
                       :output-dir "resources/public/js"
                       :asset-path "/js"
-                      :modules    {:app {:entries [{{project-ns}}.core]}}
-                      :devtools   {:after-load {{project-ns}}.core/mount-root}}}
+                      :modules    {:app {:init-fn {{project-ns}}.core/init!}}}}
  :dev-http     {3000 {:root    "resources/public"
                       :handler {{project-ns}}.handler/app}}}

--- a/resources/leiningen/new/reagent/src/clj/reagent/handler.clj
+++ b/resources/leiningen/new/reagent/src/clj/reagent/handler.clj
@@ -23,8 +23,7 @@
    (head)
    [:body {:class "body-container"}
     mount-target
-    (include-js "/js/app.js"){{#shadow-cljs-hook?}}
-    [:script "{{project-goog-module}}.core.init_BANG_()"]{{/shadow-cljs-hook?}}]))
+    (include-js "/js/app.js")]))
 
 {{#devcards-hook?}}
 

--- a/resources/leiningen/new/reagent/src/cljs/reagent/core.cljs
+++ b/resources/leiningen/new/reagent/src/cljs/reagent/core.cljs
@@ -115,3 +115,8 @@
       (boolean (reitit/match-by-path router path)))})
   (accountant/dispatch-current!)
   (mount-root))
+
+{{#shadow-cljs-hook?}}
+(defn ^:dev/after-load reload! []
+  (mount-root))
+{{/shadow-cljs-hook?}}


### PR DESCRIPTION
Should use `:init-fn` instead of having html emit a function call. `:init-fn` ensures the function is called when the JS file is loaded and enables using `<script async>`. Didn't change that part but it is recommended.

Also removed the `:after-load` from the build config since it is recommended to use metadata hooks.